### PR TITLE
Created a token for the current entity

### DIFF
--- a/secondaryinfo-entity-row.js
+++ b/secondaryinfo-entity-row.js
@@ -36,7 +36,8 @@ customElements.whenDefined('card-tools').then(() => {
             await this._wrappedElement.updateComplete;
             let secondaryInfoDiv = this._wrappedElement.shadowRoot.querySelector("hui-generic-entity-row").shadowRoot.querySelector(".secondary");
             if (secondaryInfoDiv && this._config.secondary_info) {
-                let text = window.cardTools.parseTemplate(this._config.secondary_info, 'Unable to parse secondary_info config');
+                const secondary_info_str = this._config.secondary_info.replace('<entity_id>', this._config.entity);
+                let text = window.cardTools.parseTemplate(secondary_info_str, 'Unable to parse secondary_info config');
                 secondaryInfoDiv.innerHTML = text;
             }
         }


### PR DESCRIPTION
The current implementation does not work that well with ex. monster-card.

The problem is that some cards like monster-card generates a list of entities from a given filter. 
In that situation it's impossible to create a string with  `[[ entity_id.xxxxx ]]` as the current entity id is not known.

This patch adds a "token" for the current entity.
Could be used in like this:

```
secondary_info: "[[ <entity_id>.attributes.some_attr ]]"
```

<entity_id> will be replaced with the current entity id from the config.
